### PR TITLE
🐛 fix: zero not being a valid time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,7 +343,7 @@ export class V7Generator {
 
     if (
       !Number.isInteger(unixTsMs) ||
-      unixTsMs < 1 ||
+      unixTsMs < 0 ||
       unixTsMs > 0xffff_ffff_ffff
     ) {
       throw new RangeError("`unixTsMs` must be a 48-bit positive integer");

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ export class UUID {
  * generated UUIDs. See their respective documentation for details.
  */
 export class V7Generator {
-  private timestamp = 0;
+  private timestamp: number | undefined;
   private counter = 0;
 
   /** The random number generator used by the generator. */
@@ -312,13 +312,13 @@ export class V7Generator {
    *
    * @param rollbackAllowance - The amount of `unixTsMs` rollback that is
    * considered significant. A suggested value is `10_000` (milliseconds).
-   * @throws RangeError if `unixTsMs` is not a 48-bit positive integer.
+   * @throws RangeError if `unixTsMs` is not a 48-bit positive integer or zero.
    */
   generateOrResetCore(unixTsMs: number, rollbackAllowance: number): UUID {
     let value = this.generateOrAbortCore(unixTsMs, rollbackAllowance);
     if (value === undefined) {
       // reset state and resume
-      this.timestamp = 0;
+      this.timestamp = undefined;
       value = this.generateOrAbortCore(unixTsMs, rollbackAllowance)!;
     }
     return value;
@@ -333,7 +333,7 @@ export class V7Generator {
    *
    * @param rollbackAllowance - The amount of `unixTsMs` rollback that is
    * considered significant. A suggested value is `10_000` (milliseconds).
-   * @throws RangeError if `unixTsMs` is not a 48-bit positive integer.
+   * @throws RangeError if `unixTsMs` is not a 48-bit positive integer or zero.
    */
   generateOrAbortCore(
     unixTsMs: number,
@@ -351,7 +351,7 @@ export class V7Generator {
       throw new RangeError("`rollbackAllowance` out of reasonable range");
     }
 
-    if (unixTsMs > this.timestamp) {
+    if (this.timestamp === undefined || unixTsMs > this.timestamp) {
       this.timestamp = unixTsMs;
       this.resetCounter();
     } else if (unixTsMs + rollbackAllowance >= this.timestamp) {


### PR DESCRIPTION
Hi @LiosK,

when running some of my unit tests using time mocking I discovered that a time of `0` currently spawns a RangeError even tho it's a perfectly valid time. This PR aims to fix that. 🙌

Best regards,
@lukas-runge